### PR TITLE
feature/#7_custom_error_page

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,3 @@
+export default function Custom404() {
+  return <h1>404 - Page Not Found</h1>;
+}

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,0 +1,17 @@
+// 500 Internal Server Error
+function Error({ statusCode }) {
+  return (
+    <p>
+      {statusCode ? `An error ${statusCode} occurred on server` : 'An error occurred on client'}
+    </p>
+  );
+}
+
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+
+
+export default Error;


### PR DESCRIPTION
#WHAT
404エラーと500エラーのカスタムページを実装。

#WHY
エラーページをカスタムすることで、ユーザーにどんな不具合やエラーが起きたのか明確に伝えることができるため。
